### PR TITLE
Bump version of internal setup-go action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: utilitywarehouse/go-actions/setup-go@v0.5.0
+      - uses: utilitywarehouse/go-actions/setup-go@v0.6.0
         with:
           go-version-file: 'go.mod'
       - name: test
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-    - uses: utilitywarehouse/go-actions/setup-go@v0.5.0
+    - uses: utilitywarehouse/go-actions/setup-go@v0.6.0
       with:
         go-version-file: 'go.mod'
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Dependabot needs some extra configuration to access internal action registries, so just handling this manually for now