### PR TITLE
Bump required Go to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/utilitywarehouse/manifest-checkers
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/golangci/golangci-lint v1.57.2


### PR DESCRIPTION
Because a dependency needs it[1], but also because we can. This is technically a breaking change (building the commands now requires Go 1.22) but since downstream uses could/should just use the release binaries I'm going to be a bit lazy with this

[1] https://github.com/utilitywarehouse/manifest-checkers/pull/24