### PR TITLE
[DENA-826] do not render Component kind of kustomization files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ kustomize-build-dirs takes a list of filenames, and for each one walks up the
 directory tree until it finds a directory containing `kustomization.yaml` then
 runs `kustomize build` on that directory, saving the output in the directory
 given by `--out-dir`.
+It also truncates secrets, so that we don't need to decrypt them in order to check
+if manifests are correct.
 
 This program should only be run from the root of a Git repository.
 

--- a/cmd/kustomize-build-dirs/main.go
+++ b/cmd/kustomize-build-dirs/main.go
@@ -76,7 +76,7 @@ func kustomizeBuildDirs(outDir string, doTruncateSecrets bool, filepaths []strin
 	}
 
 	kustomizationRoots, err = removeComponentKustomizations(rootDir, kustomizationRoots)
-	if err != nil {
+	if err != nil { //go-cov:skip
 		return err
 	}
 
@@ -163,7 +163,7 @@ func removeComponentKustomizations(kustomizationRoot string, paths []string) ([]
 	pathsNoComponent := []string{}
 	for _, path := range paths {
 		isComponent, err := checkIfIsComponent(filepath.Join(kustomizationRoot, path, "kustomization.yaml"))
-		if err != nil {
+		if err != nil { //go-cov:skip
 			return nil, err
 		}
 		if !isComponent {
@@ -175,7 +175,7 @@ func removeComponentKustomizations(kustomizationRoot string, paths []string) ([]
 
 func checkIfIsComponent(filepath string) (bool, error) {
 	file, err := os.Open(filepath)
-	if err != nil {
+	if err != nil { //go-cov:skip
 		return false, fmt.Errorf("failed opening kustomization file: %s: %v", filepath, err)
 	}
 	defer file.Close()
@@ -189,7 +189,7 @@ func checkIfIsComponent(filepath string) (bool, error) {
 	// Unmarshal the YAML into the struct
 	var kustomization Kustomization
 	err = yaml.Unmarshal(data, &kustomization)
-	if err != nil {
+	if err != nil { //go-cov:skip
 		log.Fatalf("Error unmarshaling YAML: %v", err)
 	}
 	return kustomization.Kind == "Component", nil

--- a/cmd/kustomize-build-dirs/main.go
+++ b/cmd/kustomize-build-dirs/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -162,7 +161,9 @@ func findKustomizationRoot(repoRoot string, relativePath string) (string, error)
 func removeComponentKustomizations(kustomizationRoot string, paths []string) ([]string, error) {
 	pathsNoComponent := []string{}
 	for _, path := range paths {
-		isComponent, err := checkIfIsComponent(filepath.Join(kustomizationRoot, path, "kustomization.yaml"))
+		isComponent, err := checkIfIsComponent(
+			filepath.Join(kustomizationRoot, path, "kustomization.yaml"),
+		)
 		if err != nil { //go-cov:skip
 			return nil, err
 		}
@@ -183,17 +184,16 @@ func checkIfIsComponent(filepath string) (bool, error) {
 	// Read the file's content
 	data, err := io.ReadAll(file)
 	if err != nil {
-		log.Fatalf("Error reading file: %v", err)
+		return false, fmt.Errorf("error reading file: %v", err)
 	}
 
 	// Unmarshal the YAML into the struct
 	var kustomization Kustomization
 	err = yaml.Unmarshal(data, &kustomization)
 	if err != nil { //go-cov:skip
-		log.Fatalf("Error unmarshaling YAML: %v", err)
+		return false, fmt.Errorf("error unmarshaling YAML: %v", err)
 	}
 	return kustomization.Kind == "Component", nil
-
 }
 
 func truncateSecrets(rootDir string, dirs []string) error {

--- a/cmd/kustomize-build-dirs/main.go
+++ b/cmd/kustomize-build-dirs/main.go
@@ -183,7 +183,7 @@ func checkIfIsComponent(filepath string) (bool, error) {
 
 	// Read the file's content
 	data, err := io.ReadAll(file)
-	if err != nil {
+	if err != nil { //go-cov:skip
 		return false, fmt.Errorf("error reading file: %v", err)
 	}
 

--- a/cmd/kustomize-build-dirs/main_test.go
+++ b/cmd/kustomize-build-dirs/main_test.go
@@ -51,7 +51,12 @@ func requireErorrPrefix(t *testing.T, err error, prefix string) {
 	t.Helper()
 
 	require.Error(t, err)
-	require.LessOrEqual(t, len(prefix), len(err.Error()), fmt.Sprintf("error cannot be shorter than prefix, err: %s, prefix: %s", err, prefix))
+	require.LessOrEqual(
+		t,
+		len(prefix),
+		len(err.Error()),
+		fmt.Sprintf("error cannot be shorter than prefix, err: %s, prefix: %s", err, prefix),
+	)
 	require.Equalf(t, prefix, err.Error()[:len(prefix)], "full error: %v", err)
 }
 

--- a/cmd/kustomize-build-dirs/main_test.go
+++ b/cmd/kustomize-build-dirs/main_test.go
@@ -388,6 +388,31 @@ func TestWriteMultipleManifests(t *testing.T) {
 	compareResults(t, outDir, expectedContents, readOutDir(t, outDir))
 }
 
+func TestWriteMultipleManifestsOneIscomponent(t *testing.T) {
+	gitDir, outDir := setupTest(t)
+
+	firstDeploymentPath := filepath.Join("first-project", "deployment.yaml")
+	firstDeploymentcontent := fmt.Sprintf(simpleDeploymentTemplate, "first-app")
+	secondDeploymentPath := filepath.Join("second-project", "deployment.yaml")
+	secondDeploymentcontent := fmt.Sprintf(simpleDeploymentTemplate, "second-app")
+	repoFiles := map[string]string{
+		firstDeploymentPath: firstDeploymentcontent,
+		filepath.Join("first-project", "kustomization.yaml"): simpleKustomization,
+		secondDeploymentPath: secondDeploymentcontent,
+		filepath.Join("second-project", "kustomization.yaml"): componentKustomization,
+	}
+	buildGitRepo(t, gitDir, repoFiles)
+	expectedContents := map[string]string{
+		"first-project": firstDeploymentcontent,
+	}
+
+	require.NoError(
+		t,
+		kustomizeBuildDirs(outDir, false, []string{firstDeploymentPath, secondDeploymentPath}),
+	)
+	compareResults(t, outDir, expectedContents, readOutDir(t, outDir))
+}
+
 func TestSecretsStubbed(t *testing.T) {
 	gitDir, outDir := setupTest(t)
 	manifestsDir := filepath.Join("src", "manifests")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.2
 	gitlab.com/matthewhughes/go-cov v0.4.0
 	golang.org/x/sync v0.7.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
 	sigs.k8s.io/controller-runtime v0.18.4
@@ -213,7 +214,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.4.7 // indirect
 	k8s.io/api v0.30.2 // indirect


### PR DESCRIPTION
[Component kustomization files](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/components.md) should not be expected to render on their own. They might be valid only in context of another Kustomization file.

Because of that, pipeline fails for correct manifests [here](https://github.com/utilitywarehouse/shared-kustomize-bases/pull/52)