### PR TITLE
Update `golines` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
       - id: golangci-lint-full
       - id: golangci-lint-config-verify
-  - repo: https://github.com/matthewhughes934/golines
-    rev: v0.12.0
+  - repo: https://github.com/segmentio/golines
+    rev: fc305205784a70b4cfc17397654f4c94e3153ce4
     hooks:
       - id: golines
   - repo: https://gitlab.com/matthewhughes/go-pre-commit


### PR DESCRIPTION
To use the original upstream repo. The reason for using the fork is outlined in[1], but the underlying issue was addressed upstream with[2] (but there's not be a tagged release since, so just pin to the commit for now)

Link: https://github.com/utilitywarehouse/dev-enablement-mono//commit/e46c244277da40785c5c592deb7e37cd50dc55fe [1]
Link: https://github.com/segmentio/golines/commit/fc305205784a70b4cfc17397654f4c94e3153ce4 [2]